### PR TITLE
add gcompat so that snappy compression works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN wget --quiet "http://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${
     ln -s kafka_${SCALA_VERSION}-${KAFKA_VERSION} /opt/kafka && \
     sed -i 's|^log.dirs=.*$|log.dirs=/var/lib/kafka|' /opt/kafka/config/server.properties && \
     # for kafka scripts
-    apk add --no-cache bash
+    apk add --no-cache bash gcompat
 
 VOLUME /var/lib/kafka
 


### PR DESCRIPTION
Hi, 

Thanks for the wonderful job. It really helped me a lot!

However, if client uses snappy compression, Kafka throws a dependency error:

```
06:10:36,586] ERROR [ReplicaManager broker=1001] Error processing append operation on partition where-change-stream-goes-0 (kafka.server.ReplicaManager)
2021-08-10T06:10:36.589822913Z java.lang.UnsatisfiedLinkError: /tmp/snappy-1.1.7-07ae56dc-2ea3-47a5-a34d-720d700269ff-libsnappyjava.so: Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /tmp/snappy-1.1.7-07ae56dc-2ea3-47a5-a34d-720d700269ff-libsnappyjava.so)
2021-08-10T06:10:36.589826794Z 	at java.
```

This PR solves this problem. I've tested under following enviroment.

```
ARG KAFKA_VERSION=1.1.0
ARG SCALA_VERSION=2.11
```

Hope this may help.

Ref: https://stackoverflow.com/questions/50288034/unsatisfiedlinkerror-tmp-snappy-1-1-4-libsnappyjava-so-error-loading-shared-li